### PR TITLE
Projection and sort bugs

### DIFF
--- a/bin/mindexer
+++ b/bin/mindexer
@@ -60,7 +60,8 @@ def main(
             if "sort" in doc:
                 query.sort = tuple(doc["sort"].keys())
             if "projection" in doc:
-                query.projection = tuple(doc["projection"].keys())
+                # ignore projection keys with 0, specifically {_id: 0}
+                query.projection = tuple([k for k, v in doc["projection"].items() if v == 1])
 
             workload.append(query)
         except Exception as e:

--- a/mindexer/utils/query.py
+++ b/mindexer/utils/query.py
@@ -215,6 +215,9 @@ class Query(object):
                 sub_idx = i
 
         def is_equality_cmp(field):
+            if field not in self.filter:
+                # it's not an equality comparison if the field isn't in the query
+                return False
             if isinstance(self.filter[field], dict):
                 # if none (= not any) of the keys start with $, then it's an equality comparison
                 return not any(key.startswith("$") for key in self.filter[field].keys())
@@ -224,7 +227,7 @@ class Query(object):
 
         if sub_idx != -1:
             # check for preceeding equality predicates
-            if all(is_equality_cmp(key) for key in list(self.filter.keys())[:sub_idx]):
+            if all(is_equality_cmp(key) for key in index[:sub_idx]):
                 return True
 
         return False

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -125,6 +125,17 @@ class TestQuery(unittest.TestCase):
         query.sort = ("Make", "City")
         self.assertTrue(query.can_use_sort(("Unladen Weight", "Make", "City", "State")))
 
+    def test_can_use_sort_linkbench_1(self):
+        query = Query.from_mql(
+            {'id1': 38020, 'link_type': 123456790, 'time': {'$gte': 0, '$lte': 9223372036854775807}, 'visibility': 1}
+        )
+        query.sort = ("time",)
+
+        self.assertTrue(
+            query.can_use_sort(('id1', 'link_type', 'visibility', 'time', 'id2', 'version', 'data'))
+        )
+
+
     def test_can_use_sort_sub_seq_preceeding_not_eq(self):
         query = Query.from_mql(
             {"Unladen Weight": {"$gt": 2000}, "Make": {"$in": ["INFIN", "HYUND"]}}


### PR DESCRIPTION
This PR fixes two bugs identified through experiments with LinkBench workloads:

1. In query projections, we must only include keys with value 1, and ignore keys with value 0. 

Example: `{foo: 1, bar: 1, _id: 0}`  the projected fields are `("foo", "bar")` but mindexer included `_id` as well.

2. There was a bug in the logic to determine if an index can be used to sort a query, specifically for condition c), see docstring of the `can_use_sort()` method. 

The algorithm iterated over the query fields but needs to iterate over the index fields instead. 

There is now a test for this specific case in `test_query.py`

